### PR TITLE
feat: divide home view into 4 components

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,4 @@
 <template>
-  <nav>
-    <router-link to="/">Home</router-link>
-  </nav>
   <router-view />
 </template>
 

--- a/src/components/LeftComponent.vue
+++ b/src/components/LeftComponent.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="left-component">Left Component</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "LeftComponent",
+});
+</script>
+
+<style scoped>
+.left-component {
+  background-color: #e74c3c;
+  padding: 10px;
+  text-align: center;
+  height: 100%;
+}
+</style>

--- a/src/components/MiddleComponent.vue
+++ b/src/components/MiddleComponent.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="middle-component">Middle Component</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "MiddleComponent",
+});
+</script>
+
+<style scoped>
+.middle-component {
+  background-color: #f39c12;
+  padding: 10px;
+  text-align: center;
+  height: 100%;
+}
+</style>

--- a/src/components/RightComponent.vue
+++ b/src/components/RightComponent.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="right-component">Right Component</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "RightComponent",
+});
+</script>
+
+<style scoped>
+.right-component {
+  background-color: #2ecc71;
+  padding: 10px;
+  text-align: center;
+  height: 100%;
+}
+</style>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="top-bar">Header</div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "TopBar",
+});
+</script>
+
+<style scoped>
+.top-bar {
+  background-color: #3498db;
+  padding: 10px;
+  text-align: center;
+  font-size: 20px;
+  color: white;
+}
+</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,14 +1,60 @@
 <template>
   <div class="home">
-    <img alt="Vue logo" src="../assets/logo.png" />
+    <TopBar />
+    <div class="content">
+      <LeftComponent class="content-left" />
+      <MiddleComponent class="content-middle" />
+      <RightComponent class="content-right" />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { Options, Vue } from "vue-class-component";
+import TopBar from "@/components/TopBar.vue";
+import LeftComponent from "@/components/LeftComponent.vue";
+import MiddleComponent from "@/components/MiddleComponent.vue";
+import RightComponent from "@/components/RightComponent.vue";
 
 @Options({
-  components: {},
+  components: {
+    TopBar,
+    LeftComponent,
+    MiddleComponent,
+    RightComponent,
+  },
 })
 export default class HomeView extends Vue {}
 </script>
+
+<style scoped>
+.home {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.content {
+  display: flex;
+  flex: 1;
+}
+
+.content-left,
+.content-middle,
+.content-right {
+  flex: 1;
+  padding: 10px;
+}
+
+.content-left {
+  border-right: 2px solid #e74c3c;
+}
+
+.content-middle {
+  border-right: 2px solid #f39c12;
+}
+
+.content-right {
+  border-right: 2px solid #2ecc71;
+}
+</style>


### PR DESCRIPTION
## Description
This PR divides home view into 4 elements
- Topbar: Will cover the generate/start-stop buttons
- Left Section: Will cover the horse lists
- Middle Section: Will cover the race simulations
- Right Section: Will cover the result tables
## Media
### Design
<img width="674" alt="Screenshot 2024-06-29 at 10 39 04" src="https://github.com/furkanYanteri1/--esac-tset-redisni--/assets/59139373/3c5d79db-3e4a-45d4-be48-93ab8696b2e9">
### Result
<img width="1424" alt="Screenshot 2024-06-29 at 10 32 24" src="https://github.com/furkanYanteri1/--esac-tset-redisni--/assets/59139373/9fbc29ca-6ec3-498f-94ec-246d12c42190">
